### PR TITLE
Uprev vrouter chart version

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ version: "0.1.0"
 appVersion: "0.1.0"
 dependencies:
 - name: xrd-vrouter
-  version: "~1.0.2-0"
+  version: "~1.0.6-0"
   repository: "https://ios-xr.github.io/xrd-helm"
   alias: xrd
   condition: xrd.enabled

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: "v2"
 name: "xrd-ha-app"
-version: "0.1.0"
-appVersion: "0.1.0"
+version: "0.1.1"
+appVersion: "0.1.1"
 dependencies:
 - name: xrd-vrouter
   version: "~1.0.6-0"


### PR DESCRIPTION
Need newer vRouter chart version to use `secret` instead of `password` in config.

Tested by manually running the ha app suite.